### PR TITLE
Fixes AttributeError popup on Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/scapy-packet_viewer.svg)](https://pypi.org/project/scapy-packet_viewer/)
 [![Documentation Status](https://readthedocs.org/projects/scapy-packet_viewer/badge/?version=latest)](https://scapy-packet_viewer.readthedocs.io/en/latest/?badge=latest)
 
-TODO: non-Travis build status
-
 # scapy-packet_viewer #
 
 Packet viewer for SecDev's [Scapy](https://scapy.net/).

--- a/scapy_packet_viewer/main_window.py
+++ b/scapy_packet_viewer/main_window.py
@@ -373,6 +373,7 @@ class MainWindow(Frame):
                 except AttributeError as e:
                     attribute_error_count += 1
                     last_exception = e
+            # Suppress attribute errors, if they don't apply for all packets in packet_view.body
             if len(self.packet_view.body) == attribute_error_count:
                 raise last_exception
         except NameError:


### PR DESCRIPTION
This PR changes the behavior of the filter function, that only if all packets don't have the Attribute on which the filter is applied to, an exception is raised and a popup shown.  